### PR TITLE
refactor: download specific dataset version to ensure reproducibility

### DIFF
--- a/Vibration.ipynb
+++ b/Vibration.ipynb
@@ -29,16 +29,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds_0D = pd.read_csv(\"input/0D.csv\", sep=',')\n",
-    "ds_0E = pd.read_csv(\"input/0E.csv\", sep=',')\n",
-    "ds_1D = pd.read_csv(\"input/1D.csv\", sep=',')\n",
-    "ds_1E = pd.read_csv(\"input/1E.csv\", sep=',')\n",
-    "ds_2D = pd.read_csv(\"input/2D.csv\", sep=',')\n",
-    "ds_2E = pd.read_csv(\"input/2E.csv\", sep=',')\n",
-    "ds_3D = pd.read_csv(\"input/3D.csv\", sep=',')\n",
-    "ds_3E = pd.read_csv(\"input/3E.csv\", sep=',')\n",
-    "ds_4D = pd.read_csv(\"input/4D.csv\", sep=',')\n",
-    "ds_4E = pd.read_csv(\"input/4E.csv\", sep=',')"
+    "import kagglehub\n",
+    "\n",
+    "# Version 1 des Datasets herunterladen, um reproduzierbare Ergebnisse zu gewährleisten\n",
+    "path = kagglehub.dataset_download(\"jishnukoliyadan/vibration-analysis-on-rotating-shaft/versions/1\")\n",
+    "\n",
+    "ds_0E = pd.read_csv(path + \"/input/0E.csv\", sep=',')\n",
+    "ds_0D = pd.read_csv(path + \"/input/0D.csv\", sep=',')\n",
+    "ds_1D = pd.read_csv(path + \"/input/1D.csv\", sep=',')\n",
+    "ds_1E = pd.read_csv(path + \"/input/1E.csv\", sep=',')\n",
+    "ds_2D = pd.read_csv(path + \"/input/2D.csv\", sep=',')\n",
+    "ds_2E = pd.read_csv(path + \"/input/2E.csv\", sep=',')\n",
+    "ds_3D = pd.read_csv(path + \"/input/3D.csv\", sep=',')\n",
+    "ds_3E = pd.read_csv(path + \"/input/3E.csv\", sep=',')\n",
+    "ds_4D = pd.read_csv(path + \"/input/4D.csv\", sep=',')\n",
+    "ds_4E = pd.read_csv(path + \"/input/4E.csv\", sep=',')"
    ]
   },
   {


### PR DESCRIPTION
Dieses Update integriert den automatischen Download von einer spezifischen Version (Version 1) des Datensatzes von Kaggle. Dadurch wird sichergestellt, dass alle Nutzer mit einer konsistenten und reproduzierbaren Datenbasis arbeiten. Der festgelegte Versionsstand verhindert, dass spätere Änderungen oder Updates am Originaldatensatz die Ergebnisse beeinflussen, und vereinfacht die Nutzung des Codes, da keine manuelle Datensatzsuche erforderlich ist. Mit dieser Anpassung wird die Transparenz und Nachvollziehbarkeit des Projekts verbessert.